### PR TITLE
fix: update extension id

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ If you want to change the default settings for the script,
 change the values in `yahe.js` source file.
 Remember to rebuild after changing the values.
 
-You can also test and check the code for lint errors using [NPM][]:
+You can also test and check the code for lint errors using NPM:
 
 ```shell
 npm install

--- a/manifest.webext.json
+++ b/manifest.webext.json
@@ -4,7 +4,7 @@
   },
   "browser_specific_settings": {
     "gecko": {
-      "id": "yahe@lepo"
+      "id": "yahe@jpallari"
     }
   }
 }


### PR DESCRIPTION
The access to the original extension was lost, so it must be reuploaded from scratch. This requires the extension ID to be updated.