### PR TITLE
fix: manifest v2 for firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ extensions that worked as an inspiration for YAHE:
 2-clause BSD license. See [LICENSE](LICENSE) for more details.
 
 [cws]: https://chrome.google.com/webstore/detail/eimkmfhfckmajkednnnhkacajflcjinm
-[ffao]: https://addons.mozilla.org/en-US/firefox/addon/yet-another-hints-extension/
+[ffao]: https://addons.mozilla.org/en-US/firefox/addon/yahe
 [edgeao]: https://microsoftedge.microsoft.com/addons/detail/yet-another-hints-extensi/oblcogekcgnkimamhnekiohhikomblod
 [git]: https://git-scm.com/
 [hhopera]: https://github.com/hogelog/hit-a-hint-opera

--- a/manifest.chrome.json
+++ b/manifest.chrome.json
@@ -1,4 +1,7 @@
 {
+  "manifest_version": 3,
+  "host_permissions": ["*://*/*"],
+  "permissions": ["storage"],
   "background": {
     "service_worker": "yahe-bg.js"
   }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,6 @@
 {
   "name": "Yet Another Hints Extension",
   "short_name": "YAHE",
-  "manifest_version": 3,
   "description": "A simple hit-a-hint extension",
   "options_ui": {
     "page": "options/index.html",
@@ -12,8 +11,6 @@
     "48": "icons/icon48.png",
     "128": "icons/icon128.png"
   },
-  "host_permissions": ["*://*/*"],
-  "permissions": ["storage"],
   "content_scripts": [
     {
       "match_about_blank": true,

--- a/manifest.webext.json
+++ b/manifest.webext.json
@@ -1,4 +1,6 @@
 {
+  "manifest_version": 2,
+  "permissions": ["storage", "*://*/*"],
   "background": {
     "scripts": ["yahe-bg.js"]
   },


### PR DESCRIPTION
Firefox does not support manifest v3 fully just yet, so it will be released as v2 for now.